### PR TITLE
file writing encoding

### DIFF
--- a/tmxt.py
+++ b/tmxt.py
@@ -17,6 +17,10 @@ import re
 import sys
 import xml.parsers.expat
 
+# rewrite temporary default encoding
+import _locale
+_locale._getdefaultlocale = (lambda *args: ['en_US', 'utf_8_sig'])
+
 def process_tmx(input, output, codelist):
     curlang  = ""
     curtuv   = []


### PR DESCRIPTION
The current version often breaks encoding on Windows as the default there is CP-1250 and files are stored in this format