### PR TITLE
Encapsulate the functionality of tmxt.py and tmxplore.py in main() 

### DIFF
--- a/tmxplore.py
+++ b/tmxplore.py
@@ -46,7 +46,7 @@ def explore(fd, ntus=10):
 
     print_result(langlist)
 
-if __name__ == '__main__':
+def main():
     arguments = docopt(__doc__, version='tmxplore 1.0')
 
     fd = sys.stdin.buffer if not arguments["INPUT_FILE"] else open(arguments["INPUT_FILE"], "rb")
@@ -56,4 +56,7 @@ if __name__ == '__main__':
         explore(fd, int(arguments["--no_tus"]))        
 
     fd.close()
-    
+
+if __name__ == '__main__':
+    main()
+

--- a/tmxt.py
+++ b/tmxt.py
@@ -84,7 +84,7 @@ def process_tmx(input, output, codelist):
     p.CharacterDataHandler = cd
     p.ParseFile(input) 
 
-if __name__ == '__main__':
+def main():
     arguments = docopt(__doc__, version='tmxt 1.1')
     
     input = sys.stdin.buffer if not arguments["INPUT_FILE"] else open(arguments["INPUT_FILE"], "rb")
@@ -97,3 +97,7 @@ if __name__ == '__main__':
     
     input.close()
     output.close()
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
Move code from `ìf __name__ == '__main__'` block to a `main()` function in order to make it easier to include this code in a package. Used in [biroamer installation](https://github.com/bitextor/biroamer/pull/5).